### PR TITLE
Using toUint96 instead of toUint64

### DIFF
--- a/contracts/EasyAuction.sol
+++ b/contracts/EasyAuction.sol
@@ -6,7 +6,7 @@ import "./libraries/IterableOrderedOrderSet.sol";
 import "@openzeppelin/contracts/math/Math.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "./libraries/IdToAddressBiMap.sol";
-import "@openzeppelin/contracts/utils/SafeCast.sol";
+import "./libraries/SafeCast.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract EasyAuction is Ownable {
@@ -318,7 +318,7 @@ contract EasyAuction is Ownable {
             auctionData[auctionId].volumeClearingPriceOrder = (
                 clearingOrderBuyAmount.mul(priceDenominator).div(priceNumerator)
             )
-                .toUint64();
+                .toUint96();
             require(
                 auctionData[auctionId].volumeClearingPriceOrder <=
                     sellAmountOfIter,
@@ -337,7 +337,7 @@ contract EasyAuction is Ownable {
                     "supplied price must be inverse initialOrderLimit"
                 );
                 auctionData[auctionId].volumeClearingPriceOrder = sumBuyAmount
-                    .toUint64();
+                    .toUint96();
                 auctionData[auctionId]
                     .clearingPriceOrder = IterableOrderedOrderSet.encodeOrder(
                     auctioneerId,

--- a/contracts/libraries/SafeCast.sol
+++ b/contracts/libraries/SafeCast.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+/**
+ * @dev Wrappers over Solidity's uintXX/intXX casting operators with added overflow
+ * checks.
+ *
+ * Logic was copied and modified from here: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/SafeCast.sol
+ */
+library SafeCast {
+    function toUint96(uint256 value) internal pure returns (uint96) {
+        require(value < 2**95, "SafeCast: value doesn't fit in 96 bits");
+        return uint96(value);
+    }
+
+    function toUint64(uint256 value) internal pure returns (uint64) {
+        require(value < 2**63, "SafeCast: value doesn't fit in 64 bits");
+        return uint64(value);
+    }
+}

--- a/contracts/libraries/SafeCast.sol
+++ b/contracts/libraries/SafeCast.sol
@@ -10,7 +10,7 @@ pragma solidity >=0.6.0 <0.8.0;
  */
 library SafeCast {
     function toUint96(uint256 value) internal pure returns (uint96) {
-        require(value < 2**95, "SafeCast: value doesn't fit in 96 bits");
+        require(value < 2**96, "SafeCast: value doesn't fit in 96 bits");
         return uint96(value);
     }
 

--- a/contracts/libraries/SafeCast.sol
+++ b/contracts/libraries/SafeCast.sol
@@ -15,7 +15,7 @@ library SafeCast {
     }
 
     function toUint64(uint256 value) internal pure returns (uint64) {
-        require(value < 2**63, "SafeCast: value doesn't fit in 64 bits");
+        require(value < 2**64, "SafeCast: value doesn't fit in 64 bits");
         return uint64(value);
     }
 }


### PR DESCRIPTION
Awesome catch @fedgiac 

Creating my own library for casting, as uint96 casting is not supported by openzepplin. Later on, we should submit a PR to them.