### PR TITLE
Account for minimum amount in bid token

### DIFF
--- a/contracts/EasyAuction.sol
+++ b/contracts/EasyAuction.sol
@@ -173,10 +173,10 @@ contract EasyAuction is Ownable {
                     sellAmountOfInitialAuctionOrder.mul(_sellAmounts[i]),
                 "limit price not better than mimimal offer"
             );
-            // orders size should have a minimum size, in order
-            // to limit price calculation gas consumption
+            // orders should have a minimum bid size in order to limit the gas
+            // required to compute the final price of the auction.
             require(
-                _minBuyAmounts[i] > auctionData[auctionId].minimumBiddingAmount,
+                _sellAmounts[i] > auctionData[auctionId].minimumBiddingAmount,
                 "order too small"
             );
             bool success =


### PR DESCRIPTION
This PR changes the minimum amount of an order to be priced in the bid token rather than in the auction token.

The goal is avoiding this scenario: If the auction is very successful, then the minimum amount of IDO token becomes very expensive. This could be the case if the IDO company underestimated the value of their own token and set the minimum amount too high. Then, only users with a large amount of funds are able to bid. This leads to a lowering of the final price, since less people are allowed to buy, as well as to an unfair distribution of the auctioned token.

The drawback of this change is that settling an auction can become very expensive if the auction is successful. I think this is ok as long as the minimum amount is at least as high as the gas cost for settling an order in bid token (ETH/DAi).

Note that the variable doesn't need to be rename, since it already refers to the bid token.