### PR TITLE
Fix variable labeling in CancellationSellOrder

### DIFF
--- a/contracts/EasyAuction.sol
+++ b/contracts/EasyAuction.sol
@@ -63,8 +63,8 @@ contract EasyAuction is Ownable {
     event CancellationSellOrder(
         uint256 indexed auctionId,
         uint64 indexed userId,
-        uint96 sellAmount,
-        uint96 buyAmount
+        uint96 buyAmount,
+        uint96 sellAmount
     );
     event ClaimedFromOrder(
         uint256 indexed auctionId,


### PR DESCRIPTION
The labeling of the variables defining the event `CancellationSellOrder` is inconsistent with the other events in the contract.
Note that the event is currently used with the wrong order of arguments on main, so this PR does not need to change how the event is used in the code.

### Test plan
`Ctrl + F` the string `CancellationSellOrder` here:
https://github.com/gnosis/ido-contracts/blob/main/contracts/EasyAuction.sol#L256-L261
Confirm that this is the only instance of `CancellationSellOrder` and that it's already consistent with the changes of this PR.