### PR TITLE
.npmignore ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules
 build
-client/src/contracts/*
 env/*
 coverage/*
 coverage.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
 node_modules
-client/src/contracts/*
 env/*
 coverage/*
 coverage.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+node_modules
+client/src/contracts/*
+env/*
+coverage/*
+coverage.json
+test/*
+assets/*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/ido-contracts",
-  "version": "0.0.1-alpha.4",
+  "version": "0.0.1-alpha.6",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
for leaner npm packages and including build folder in npm package and I did an immediate release of alpha 0.6, as I needed the "ERCMintable"-abis for rust.
