### PR TITLE
Require initialized auction when calling functions

### DIFF
--- a/contracts/EasyAuction.sol
+++ b/contracts/EasyAuction.sol
@@ -39,7 +39,8 @@ contract EasyAuction is Ownable {
 
     modifier atStageSolutionSubmission(uint256 auctionId) {
         require(
-            block.timestamp > auctionData[auctionId].auctionEndDate &&
+            auctionIsInitialized(auctionId) &&
+                block.timestamp > auctionData[auctionId].auctionEndDate &&
                 auctionData[auctionId].clearingPriceOrder == bytes32(0),
             "Auction not in solution submission phase"
         );
@@ -414,6 +415,7 @@ contract EasyAuction is Ownable {
             uint256 sumBiddingTokenAmount
         )
     {
+        require(auctionIsInitialized(auctionId), "auction is not initialized");
         for (uint256 i = 0; i < orders.length; i++) {
             require(
                 sellOrders[auctionId].removeWithHighSuccessRate(
@@ -469,6 +471,7 @@ contract EasyAuction is Ownable {
         internal
         returns (uint256 auctioningTokenAmount, uint256 biddingTokenAmount)
     {
+        require(auctionIsInitialized(auctionId), "auction is not initialized");
         (uint64 auctioneerId, uint96 buyAmount, uint96 sellAmount) =
             auctionData[auctionId].initialAuctionOrder.decodeOrder();
         auctionData[auctionId].initialAuctionOrder = bytes32(0);
@@ -566,6 +569,14 @@ contract EasyAuction is Ownable {
             userId = registerUser(user);
             emit NewUser(userId, user);
         }
+    }
+
+    function auctionIsInitialized(uint256 auctionId)
+        public
+        view
+        returns (bool)
+    {
+        return auctionData[auctionId].initialAuctionOrder != bytes32(0);
     }
 
     function getSecondsRemainingInBatch(uint256 auctionId)

--- a/contracts/EasyAuction.sol
+++ b/contracts/EasyAuction.sol
@@ -576,7 +576,9 @@ contract EasyAuction is Ownable {
         view
         returns (bool)
     {
-        return auctionData[auctionId].initialAuctionOrder != bytes32(0);
+        return
+            auctionData[auctionId].initialAuctionOrder != bytes32(0) ||
+            auctionData[auctionId].clearingPriceOrder != bytes32(0);
     }
 
     function getSecondsRemainingInBatch(uint256 auctionId)

--- a/contracts/EasyAuction.sol
+++ b/contracts/EasyAuction.sol
@@ -38,12 +38,15 @@ contract EasyAuction is Ownable {
     }
 
     modifier atStageSolutionSubmission(uint256 auctionId) {
-        require(
-            auctionIsInitialized(auctionId) &&
-                block.timestamp > auctionData[auctionId].auctionEndDate &&
-                auctionData[auctionId].clearingPriceOrder == bytes32(0),
-            "Auction not in solution submission phase"
-        );
+        {
+            uint256 auctionEndDate = auctionData[auctionId].auctionEndDate;
+            require(
+                auctionEndDate != 0 &&
+                    block.timestamp > auctionEndDate &&
+                    auctionData[auctionId].clearingPriceOrder == bytes32(0),
+                "Auction not in solution submission phase"
+            );
+        }
         _;
     }
 
@@ -415,7 +418,6 @@ contract EasyAuction is Ownable {
             uint256 sumBiddingTokenAmount
         )
     {
-        require(auctionIsInitialized(auctionId), "auction is not initialized");
         for (uint256 i = 0; i < orders.length; i++) {
             require(
                 sellOrders[auctionId].removeWithHighSuccessRate(
@@ -471,7 +473,6 @@ contract EasyAuction is Ownable {
         internal
         returns (uint256 auctioningTokenAmount, uint256 biddingTokenAmount)
     {
-        require(auctionIsInitialized(auctionId), "auction is not initialized");
         (uint64 auctioneerId, uint96 buyAmount, uint96 sellAmount) =
             auctionData[auctionId].initialAuctionOrder.decodeOrder();
         auctionData[auctionId].initialAuctionOrder = bytes32(0);
@@ -569,16 +570,6 @@ contract EasyAuction is Ownable {
             userId = registerUser(user);
             emit NewUser(userId, user);
         }
-    }
-
-    function auctionIsInitialized(uint256 auctionId)
-        public
-        view
-        returns (bool)
-    {
-        return
-            auctionData[auctionId].initialAuctionOrder != bytes32(0) ||
-            auctionData[auctionId].clearingPriceOrder != bytes32(0);
     }
 
     function getSecondsRemainingInBatch(uint256 auctionId)


### PR DESCRIPTION
This PR disallows calling functions on an auction that has not been initialized. Note that this is already implicit in most stage definitions except solution submission.

@josojo, do you know why the tests are failing? It looks like all failing tests are already initializing the auction, so the new check should not influence them.