### PR TITLE
Disallow degenerate auction prices

### DIFF
--- a/contracts/EasyAuction.sol
+++ b/contracts/EasyAuction.sol
@@ -142,6 +142,8 @@ contract EasyAuction is Ownable {
                 FEE_DENOMINATOR
             )
         );
+        require(_auctionedSellAmount > 0, "cannot auction zero tokens");
+        require(_minBuyAmount > 0, "tokens cannot be auctioned for free");
         require(
             minimumBiddingAmount > 0,
             "minimumBiddingAmount is not allowed to be zero"

--- a/test/contract/EasyAuction.spec.ts
+++ b/test/contract/EasyAuction.spec.ts
@@ -50,6 +50,50 @@ describe("EasyAuction", async () => {
         ),
       ).to.be.revertedWith("minimumBiddingAmount is not allowed to be zero");
     });
+    it("throws if auctioned amount is zero", async () => {
+      const {
+        auctioningToken,
+        biddingToken,
+      } = await createTokensAndMintAndApprove(
+        easyAuction,
+        [user_1, user_2],
+        hre,
+      );
+
+      await expect(
+        easyAuction.initiateAuction(
+          auctioningToken.address,
+          biddingToken.address,
+          60 * 60,
+          60 * 60,
+          0,
+          ethers.utils.parseEther("1"),
+          1,
+        ),
+      ).to.be.revertedWith("cannot auction zero tokens");
+    });
+    it("throws if auction is a giveaway", async () => {
+      const {
+        auctioningToken,
+        biddingToken,
+      } = await createTokensAndMintAndApprove(
+        easyAuction,
+        [user_1, user_2],
+        hre,
+      );
+
+      await expect(
+        easyAuction.initiateAuction(
+          auctioningToken.address,
+          biddingToken.address,
+          60 * 60,
+          60 * 60,
+          ethers.utils.parseEther("1"),
+          0,
+          1,
+        ),
+      ).to.be.revertedWith("tokens cannot be auctioned for free");
+    });
     it("initiateAuction stores the parameters correctly", async () => {
       const {
         auctioningToken,


### PR DESCRIPTION
Allowing the initial auction price to be zero, infinity, or undetermined leads to many edge cases that are fragile and hard to reason through.
Moreover, when selecting the price in `verifyPrice` we require that the price is nonzero, meaning that if a giveaway is started (`price = 0`) and not enough people participate, the fund might get stuck.

### Test plan
New unit tests.