### PR TITLE
Remove edge case: list not initialized

### DIFF
--- a/contracts/EasyAuction.sol
+++ b/contracts/EasyAuction.sol
@@ -153,6 +153,7 @@ contract EasyAuction is Ownable {
             "minimumBiddingAmount is not allowed to be zero"
         );
         auctionCounter++;
+        sellOrders[auctionCounter].initializeEmptyList();
         auctionData[auctionCounter] = AuctionData(
             _auctioningToken,
             _biddingToken,

--- a/contracts/test/IterableOrderedOrderSetWrapper.sol
+++ b/contracts/test/IterableOrderedOrderSetWrapper.sol
@@ -7,6 +7,10 @@ contract IterableOrderedOrderSetWrapper {
 
     IterableOrderedOrderSet.Data internal data;
 
+    function initializeEmptyList() public {
+        data.initializeEmptyList();
+    }
+
     function insert(bytes32 value) public returns (bool) {
         return data.insert(value, IterableOrderedOrderSet.QUEUE_START);
     }

--- a/test/contract/IteratableOrderSet.spec.ts
+++ b/test/contract/IteratableOrderSet.spec.ts
@@ -60,6 +60,7 @@ describe("IterableOrderedOrderSet", function () {
     );
 
     set = await IterableOrderedOrderSetWrapper.deploy();
+    await set.initializeEmptyList();
   });
 
   it("should contain the added values", async () => {


### PR DESCRIPTION
The linked lists we use are never initialized, which means that we have to remember to consider the edge case of an uninitialized list in different parts of the code as well as remembering it in new code.
This PR does away with this case by initializing the list on creation.

Note: I believe that it should be possible to remove an extra check in `verifyPrice` for `!sellOrders[auctionId].isEmpty()`, but the consequences of that are not clear to me of yet. Since the price finding is planned to be reworked, I didn't change it in this PR and don't plan to.

### Test plan
Existing unit tests (after initialization) work.