### PR TITLE
Revert-free insertion

### DIFF
--- a/contracts/libraries/IterableOrderedOrderSet.sol
+++ b/contracts/libraries/IterableOrderedOrderSet.sol
@@ -60,8 +60,8 @@ library IterableOrderedOrderSet {
             return false;
         }
         if (
-            !(elementBeforeNewOne == QUEUE_START ||
-                contains(self, elementBeforeNewOne))
+            elementBeforeNewOne != QUEUE_START &&
+            self.prevMap[elementBeforeNewOne] == bytes32(0)
         ) {
             return false;
         }
@@ -77,7 +77,7 @@ library IterableOrderedOrderSet {
         // Note that following the link backwards returns elements that are
         // before `elementBeforeNewOne` in sorted order.
         while (self.nextMap[elementBeforeNewOne] == bytes32(0)) {
-            elementBeforeNewOne = self.nextMap[elementBeforeNewOne];
+            elementBeforeNewOne = self.prevMap[elementBeforeNewOne];
         }
 
         // `elementBeforeNewOne` belongs now to the linked list. We search the

--- a/contracts/libraries/IterableOrderedOrderSet.sol
+++ b/contracts/libraries/IterableOrderedOrderSet.sol
@@ -14,6 +14,17 @@ library IterableOrderedOrderSet {
     bytes32 internal constant QUEUE_END =
         0xffffffffffffffffffffffffffffffffffffffff000000000000000000000001;
 
+    /// The struct is used to implement a modified version of a doubly linked
+    /// list with sorted elements. The list starts from QUEUE_START to
+    /// QUEUE_END, and each node keeps track of its predecessor and successor.
+    /// Nodes can be added or removed.
+    ///
+    /// `next` and `prev` have a different role. The list is supposed to be
+    /// traversed with `next`. If `next` is empty, the node is not part of the
+    /// list. However, `prev` might be set for elements that are not in the
+    /// list, which is why it should not be used for traversing. Having a `prev`
+    /// set for elements not in the list is used to keep track of the history of
+    /// the position in the list of a removed element.
     struct Data {
         mapping(bytes32 => bytes32) nextMap;
         mapping(bytes32 => bytes32) prevMap;
@@ -32,18 +43,6 @@ library IterableOrderedOrderSet {
 
     function isEmpty(Data storage self) internal view returns (bool) {
         return self.nextMap[QUEUE_START] == QUEUE_END;
-    }
-
-    function insertWithHighSuccessRate(
-        Data storage self,
-        bytes32 elementToInsert,
-        bytes32 elementBeforeNewOne,
-        bytes32 secondElementBeforeNewOne
-    ) internal returns (bool success) {
-        success = insert(self, elementToInsert, elementBeforeNewOne);
-        if (!success) {
-            success = insert(self, elementToInsert, secondElementBeforeNewOne);
-        }
     }
 
     function insert(
@@ -70,11 +69,21 @@ library IterableOrderedOrderSet {
             return false;
         }
 
+        // `elementBeforeNewOne` might have been removed during the time it
+        // took to the transaction calling this function to be mined, so
+        // the new order cannot be appended directly to this. We follow the
+        // history of previous links backwards until we find an element in
+        // the list from which to start our search.
+        // Note that following the link backwards returns elements that are
+        // before `elementBeforeNewOne` in sorted order.
+        while (self.nextMap[elementBeforeNewOne] == bytes32(0)) {
+            elementBeforeNewOne = self.nextMap[elementBeforeNewOne];
+        }
+
+        // `elementBeforeNewOne` belongs now to the linked list. We search the
+        // largest entry that is smaller than the element to insert.
         bytes32 previous;
         bytes32 current = elementBeforeNewOne;
-        // elementBeforeNewOne can be any element smaller than the element
-        // to insert. We want to keep the elements sorted after inserting
-        // elementToInsert.
         do {
             previous = current;
             current = self.nextMap[current];
@@ -88,7 +97,10 @@ library IterableOrderedOrderSet {
         return true;
     }
 
-    function remove(Data storage self, bytes32 elementToRemove)
+    /// The element is removed from the linked list, but the node retains
+    /// information on which predecessor it had, so that a node in the chain
+    /// can be reached by following the predecessor chain of deleted elements.
+    function removeKeepHistory(Data storage self, bytes32 elementToRemove)
         internal
         returns (bool)
     {
@@ -99,9 +111,23 @@ library IterableOrderedOrderSet {
         bytes32 nextElement = self.nextMap[elementToRemove];
         self.nextMap[previousElement] = nextElement;
         self.prevMap[nextElement] = previousElement;
-        self.prevMap[elementToRemove] = bytes32(0);
         self.nextMap[elementToRemove] = bytes32(0);
         return true;
+    }
+
+    /// Remove an element from the chain, clearing all related storage.
+    /// Note that no elements should be inserted using as a reference point a
+    /// node deleted after calling `remove`, since an element in the `prev`
+    /// chain might be missing.
+    function remove(Data storage self, bytes32 elementToRemove)
+        internal
+        returns (bool)
+    {
+        bool result = removeKeepHistory(self, elementToRemove);
+        if (result) {
+            self.prevMap[elementToRemove] = bytes32(0);
+        }
+        return result;
     }
 
     function contains(Data storage self, bytes32 value)

--- a/contracts/test/IterableOrderedOrderSetWrapper.sol
+++ b/contracts/test/IterableOrderedOrderSetWrapper.sol
@@ -19,16 +19,12 @@ contract IterableOrderedOrderSetWrapper {
         return data.insert(value, at);
     }
 
-    function insertWithHighSuccessRate(
-        bytes32 value,
-        bytes32 at,
-        bytes32 at2
-    ) public returns (bool) {
-        return data.insertWithHighSuccessRate(value, at, at2);
-    }
-
     function remove(bytes32 value) public returns (bool) {
         return data.remove(value);
+    }
+
+    function removeKeepHistory(bytes32 value) public returns (bool) {
+        return data.removeKeepHistory(value);
     }
 
     function contains(bytes32 value) public view returns (bool) {

--- a/contracts/test/IterableOrderedOrderSetWrapper.sol
+++ b/contracts/test/IterableOrderedOrderSetWrapper.sol
@@ -43,6 +43,14 @@ contract IterableOrderedOrderSetWrapper {
         return data.next(value);
     }
 
+    function nextMap(bytes32 value) public view returns (bytes32) {
+        return data.nextMap[value];
+    }
+
+    function prevMap(bytes32 value) public view returns (bytes32) {
+        return data.prevMap[value];
+    }
+
     function decodeOrder(bytes32 value)
         public
         pure

--- a/src/priceCalculation.ts
+++ b/src/priceCalculation.ts
@@ -279,7 +279,6 @@ export async function placeOrders(
         [sellOrder.buyAmount],
         [sellOrder.sellAmount],
         [queueStartElement],
-        [queueStartElement],
       );
   }
 }

--- a/test/contract/EasyAuction.spec.ts
+++ b/test/contract/EasyAuction.spec.ts
@@ -176,7 +176,6 @@ describe("EasyAuction", async () => {
           [ethers.utils.parseEther("1")],
           [ethers.utils.parseEther("1").add(1)],
           [queueStartElement],
-          [queueStartElement],
         ),
       ).to.be.revertedWith("no longer in order placement phase");
     });
@@ -207,7 +206,6 @@ describe("EasyAuction", async () => {
           [ethers.utils.parseEther("1")],
           [ethers.utils.parseEther("1").add(1)],
           [queueStartElement],
-          [queueStartElement],
         ),
       ).to.be.revertedWith("no longer in order placement phase");
     });
@@ -237,7 +235,6 @@ describe("EasyAuction", async () => {
           [ethers.utils.parseEther("1").add(1)],
           [ethers.utils.parseEther("1")],
           [queueStartElement],
-          [queueStartElement],
         ),
       ).to.be.revertedWith("limit price not better than mimimal offer");
       await expect(
@@ -245,7 +242,6 @@ describe("EasyAuction", async () => {
           auctionId,
           [ethers.utils.parseEther("1")],
           [ethers.utils.parseEther("1")],
-          [queueStartElement],
           [queueStartElement],
         ),
       ).to.be.revertedWith("limit price not better than mimimal offer");
@@ -282,7 +278,6 @@ describe("EasyAuction", async () => {
         [buyAmount, buyAmount],
         [sellAmount, sellAmount.add(1)],
         [queueStartElement, queueStartElement],
-        [queueStartElement, queueStartElement],
       );
       const transferredbiddingTokenAmount = sellAmount.add(sellAmount.add(1));
 
@@ -293,51 +288,7 @@ describe("EasyAuction", async () => {
         balanceBeforeOrderPlacement.sub(transferredbiddingTokenAmount),
       );
     });
-    it("places a new order via fallbackPrevSellOrder", async () => {
-      const {
-        auctioningToken,
-        biddingToken,
-      } = await createTokensAndMintAndApprove(
-        easyAuction,
-        [user_1, user_2],
-        hre,
-      );
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
-        easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        ethers.utils.parseEther("1"),
-        ethers.utils.parseEther("1"),
-        1,
-      );
-
-      const balanceBeforeOrderPlacement = await biddingToken.balanceOf(
-        user_1.address,
-      );
-      const sellAmount = ethers.utils.parseEther("1").add(1);
-      const buyAmount = ethers.utils.parseEther("1");
-      const arbitraryElement =
-        "0x0000000000000000000001000000000000000000000000000000000000000005";
-      await easyAuction.placeSellOrders(
-        auctionId,
-        [buyAmount],
-        [sellAmount],
-        [arbitraryElement],
-        [queueStartElement],
-      );
-      const transferredbiddingTokenAmount = sellAmount;
-
-      expect(await biddingToken.balanceOf(easyAuction.address)).to.equal(
-        transferredbiddingTokenAmount,
-      );
-      expect(await biddingToken.balanceOf(user_1.address)).to.equal(
-        balanceBeforeOrderPlacement.sub(transferredbiddingTokenAmount),
-      );
-    });
-    it("fallbackPrevSellOrder does not place an order twice", async () => {
+    it("an order is only placed once", async () => {
       const {
         auctioningToken,
         biddingToken,
@@ -365,7 +316,6 @@ describe("EasyAuction", async () => {
         auctionId,
         [buyAmount],
         [sellAmount],
-        [queueStartElement],
         [queueStartElement],
       );
       const allPlacedOrders = await getAllSellOrders(easyAuction, auctionId);
@@ -411,7 +361,6 @@ describe("EasyAuction", async () => {
           sellOrders.map((buyOrder) => buyOrder.buyAmount),
           sellOrders.map((buyOrder) => buyOrder.sellAmount),
           Array(sellOrders.length).fill(queueStartElement),
-          Array(sellOrders.length).fill(queueStartElement),
         ),
       ).to.be.revertedWith("order too small");
     });
@@ -447,7 +396,6 @@ describe("EasyAuction", async () => {
           auctionId,
           [buyAmount, buyAmount],
           [sellAmount, sellAmount.add(1)],
-          [queueStartElement, queueStartElement],
           [queueStartElement, queueStartElement],
         ),
       ).to.be.revertedWith("ERC20: transfer amount exceeds allowance");

--- a/test/contract/IteratableOrderSet.spec.ts
+++ b/test/contract/IteratableOrderSet.spec.ts
@@ -264,14 +264,23 @@ describe("IterableOrderedOrderSet", function () {
       await set.insert(BYTES32_TWO);
       await set.insert(BYTES32_THREE);
       await set.insert(BYTES32_FIVE);
+      // 1 ─> 2 ─> 3 ─> 5
 
       await set.removeKeepHistory(BYTES32_TWO);
+      // 1  ─> 3 ─> 5
+      // └───> 2
       expect(await set.prevMap(BYTES32_TWO)).to.equal(BYTES32_ONE);
       expect(await set.nextMap(BYTES32_TWO)).to.equal(ethers.constants.Zero);
       await set.removeKeepHistory(BYTES32_THREE);
+      // 1 ─> 5
+      // └──> 2
+      // └──> 3
       expect(await set.prevMap(BYTES32_THREE)).to.equal(BYTES32_ONE);
       expect(await set.nextMap(BYTES32_THREE)).to.equal(ethers.constants.Zero);
       await set.insertAt(BYTES32_FOUR, BYTES32_TWO);
+      // 1 ─> 4 ─> 5
+      // └──> 2
+      // └──> 3
 
       const first = await set.first();
       const second = await set.next(first);
@@ -289,14 +298,23 @@ describe("IterableOrderedOrderSet", function () {
       await set.insert(BYTES32_TWO);
       await set.insert(BYTES32_THREE);
       await set.insert(BYTES32_FIVE);
+      // 1 ─> 2 ─> 3 ─> 5
 
       await set.removeKeepHistory(BYTES32_THREE);
+      // 1 ─> 2 ─> 5
+      //      └──> 3
       expect(await set.prevMap(BYTES32_THREE)).to.equal(BYTES32_TWO);
       expect(await set.nextMap(BYTES32_THREE)).to.equal(ethers.constants.Zero);
       await set.removeKeepHistory(BYTES32_TWO);
+      // 1 ─> 5
+      // └──> 2
+      //      └──> 3
       expect(await set.prevMap(BYTES32_TWO)).to.equal(BYTES32_ONE);
       expect(await set.nextMap(BYTES32_TWO)).to.equal(ethers.constants.Zero);
-      await set.insertAt(BYTES32_FOUR, BYTES32_TWO);
+      await set.insertAt(BYTES32_FOUR, BYTES32_THREE);
+      // 1 ─> 4 ─> 5
+      // └──> 2
+      //      └──> 3
 
       const first = await set.first();
       const second = await set.next(first);
@@ -313,16 +331,23 @@ describe("IterableOrderedOrderSet", function () {
       await set.insert(BYTES32_ONE);
       await set.insert(BYTES32_TWO);
       await set.insert(BYTES32_FIVE);
+      // 1 ─> 2 ─> 5
 
       await set.removeKeepHistory(BYTES32_TWO);
+      // 1 ─> 5
+      // └──> 2
       expect(await set.prevMap(BYTES32_TWO)).to.equal(BYTES32_ONE);
       expect(await set.nextMap(BYTES32_TWO)).to.equal(ethers.constants.Zero);
 
       await set.insert(BYTES32_THREE);
+      // 1 ─> 3 ─> 5
+      // └──> 2
       expect(await set.prevMap(BYTES32_THREE)).to.equal(BYTES32_ONE);
       expect(await set.nextMap(BYTES32_THREE)).to.equal(BYTES32_FIVE);
 
       await set.insertAt(BYTES32_FOUR, BYTES32_TWO);
+      // 1 ─> 3 ─> 4 ─> 5
+      // └──> 2
       expect(await set.prevMap(BYTES32_FOUR)).to.equal(BYTES32_THREE);
       expect(await set.nextMap(BYTES32_FOUR)).to.equal(BYTES32_FIVE);
 

--- a/test/contract/IteratableOrderSet.spec.ts
+++ b/test/contract/IteratableOrderSet.spec.ts
@@ -147,36 +147,6 @@ describe("IterableOrderedOrderSet", function () {
       set.callStatic.insertAt(queueLastElement, queueStartElement),
     ).to.be.revertedWith("Inserting element is not valid");
   });
-  it("should allow to insert element with insertWithHighSuccessRate", async () => {
-    await set.insert(BYTES32_ONE);
-
-    expect(
-      await set.callStatic.insertWithHighSuccessRate(
-        BYTES32_TWO,
-        BYTES32_THREE,
-        BYTES32_ONE,
-      ),
-    ).to.equal(true);
-    await set.insertWithHighSuccessRate(
-      BYTES32_TWO,
-      BYTES32_THREE,
-      BYTES32_ONE,
-    );
-    expect(
-      await set.callStatic.insertWithHighSuccessRate(
-        BYTES32_TWO,
-        BYTES32_THREE,
-        BYTES32_ONE,
-      ),
-    ).to.equal(false);
-    expect(
-      await set.callStatic.insertWithHighSuccessRate(
-        BYTES32_TWO,
-        BYTES32_THREE,
-        BYTES32_THREE,
-      ),
-    ).to.equal(false);
-  });
 
   it("should insert element according to rate", async () => {
     await set.insert(BYTES32_THREE);

--- a/test/contract/IteratableOrderSet.spec.ts
+++ b/test/contract/IteratableOrderSet.spec.ts
@@ -8,6 +8,8 @@ import {
   encodeOrder,
 } from "../../src/priceCalculation";
 
+const QUEUE_END =
+  "0xffffffffffffffffffffffffffffffffffffffff000000000000000000000001";
 const BYTES32_ZERO = encodeOrder({
   userId: BigNumber.from(0),
   sellAmount: BigNumber.from(0),
@@ -36,6 +38,16 @@ const BYTES32_TWO = encodeOrder({
 const BYTES32_THREE = encodeOrder({
   userId: BigNumber.from(1),
   buyAmount: BigNumber.from(6),
+  sellAmount: BigNumber.from(2),
+});
+const BYTES32_FOUR = encodeOrder({
+  userId: BigNumber.from(1),
+  buyAmount: BigNumber.from(8),
+  sellAmount: BigNumber.from(2),
+});
+const BYTES32_FIVE = encodeOrder({
+  userId: BigNumber.from(1),
+  buyAmount: BigNumber.from(10),
   sellAmount: BigNumber.from(2),
 });
 
@@ -188,9 +200,30 @@ describe("IterableOrderedOrderSet", function () {
 
     const first = await set.first();
     const second = await set.next(first);
+    const prev_of_removed = await set.prevMap(BYTES32_TWO);
+    const next_of_removed = await set.nextMap(BYTES32_TWO);
 
     expect(first).to.equal(BYTES32_ONE);
     expect(second).to.equal(BYTES32_THREE);
+    expect(prev_of_removed).to.equal(ethers.constants.Zero);
+    expect(next_of_removed).to.equal(ethers.constants.Zero);
+  });
+  it("should remove element keeping history", async () => {
+    await set.insert(BYTES32_THREE);
+    await set.insert(BYTES32_ONE);
+    await set.insert(BYTES32_TWO);
+
+    await set.removeKeepHistory(BYTES32_TWO);
+
+    const first = await set.first();
+    const second = await set.next(first);
+    const prev_of_removed = await set.prevMap(BYTES32_TWO);
+    const next_of_removed = await set.nextMap(BYTES32_TWO);
+
+    expect(first).to.equal(BYTES32_ONE);
+    expect(second).to.equal(BYTES32_THREE);
+    expect(prev_of_removed).to.equal(BYTES32_ONE);
+    expect(next_of_removed).to.equal(ethers.constants.Zero);
   });
 
   it("should allow to remove element twice", async () => {
@@ -201,6 +234,110 @@ describe("IterableOrderedOrderSet", function () {
     expect(await set.callStatic.remove(BYTES32_TWO)).to.equal(true);
     await set.remove(BYTES32_TWO);
     expect(await set.callStatic.remove(BYTES32_TWO)).to.equal(false);
+  });
+
+  describe("insert elements using removed element as reference", () => {
+    it("single element removed", async () => {
+      await set.insert(BYTES32_ONE);
+      await set.insert(BYTES32_TWO);
+      await set.insert(BYTES32_FOUR);
+
+      await set.removeKeepHistory(BYTES32_TWO);
+      expect(
+        await set.callStatic.insertAt(BYTES32_THREE, BYTES32_TWO),
+      ).to.equal(true);
+      await set.insertAt(BYTES32_THREE, BYTES32_TWO);
+
+      const first = await set.first();
+      const second = await set.next(first);
+      const third = await set.next(second);
+      const next_of_third = await set.nextMap(third);
+
+      expect(first).to.equal(BYTES32_ONE);
+      expect(second).to.equal(BYTES32_THREE);
+      expect(third).to.equal(BYTES32_FOUR);
+      expect(next_of_third).to.equal(QUEUE_END);
+    });
+
+    it("two elements removed, backtrack once", async () => {
+      await set.insert(BYTES32_ONE);
+      await set.insert(BYTES32_TWO);
+      await set.insert(BYTES32_THREE);
+      await set.insert(BYTES32_FIVE);
+
+      await set.removeKeepHistory(BYTES32_TWO);
+      expect(await set.prevMap(BYTES32_TWO)).to.equal(BYTES32_ONE);
+      expect(await set.nextMap(BYTES32_TWO)).to.equal(ethers.constants.Zero);
+      await set.removeKeepHistory(BYTES32_THREE);
+      expect(await set.prevMap(BYTES32_THREE)).to.equal(BYTES32_ONE);
+      expect(await set.nextMap(BYTES32_THREE)).to.equal(ethers.constants.Zero);
+      await set.insertAt(BYTES32_FOUR, BYTES32_TWO);
+
+      const first = await set.first();
+      const second = await set.next(first);
+      const third = await set.next(second);
+      const next_of_third = await set.nextMap(third);
+
+      expect(first).to.equal(BYTES32_ONE);
+      expect(second).to.equal(BYTES32_FOUR);
+      expect(third).to.equal(BYTES32_FIVE);
+      expect(next_of_third).to.equal(QUEUE_END);
+    });
+
+    it("two elements removed, backtrack twice", async () => {
+      await set.insert(BYTES32_ONE);
+      await set.insert(BYTES32_TWO);
+      await set.insert(BYTES32_THREE);
+      await set.insert(BYTES32_FIVE);
+
+      await set.removeKeepHistory(BYTES32_THREE);
+      expect(await set.prevMap(BYTES32_THREE)).to.equal(BYTES32_TWO);
+      expect(await set.nextMap(BYTES32_THREE)).to.equal(ethers.constants.Zero);
+      await set.removeKeepHistory(BYTES32_TWO);
+      expect(await set.prevMap(BYTES32_TWO)).to.equal(BYTES32_ONE);
+      expect(await set.nextMap(BYTES32_TWO)).to.equal(ethers.constants.Zero);
+      await set.insertAt(BYTES32_FOUR, BYTES32_TWO);
+
+      const first = await set.first();
+      const second = await set.next(first);
+      const third = await set.next(second);
+      const next_of_third = await set.nextMap(third);
+
+      expect(first).to.equal(BYTES32_ONE);
+      expect(second).to.equal(BYTES32_FOUR);
+      expect(third).to.equal(BYTES32_FIVE);
+      expect(next_of_third).to.equal(QUEUE_END);
+    });
+
+    it("one element removed, one added", async () => {
+      await set.insert(BYTES32_ONE);
+      await set.insert(BYTES32_TWO);
+      await set.insert(BYTES32_FIVE);
+
+      await set.removeKeepHistory(BYTES32_TWO);
+      expect(await set.prevMap(BYTES32_TWO)).to.equal(BYTES32_ONE);
+      expect(await set.nextMap(BYTES32_TWO)).to.equal(ethers.constants.Zero);
+
+      await set.insert(BYTES32_THREE);
+      expect(await set.prevMap(BYTES32_THREE)).to.equal(BYTES32_ONE);
+      expect(await set.nextMap(BYTES32_THREE)).to.equal(BYTES32_FIVE);
+
+      await set.insertAt(BYTES32_FOUR, BYTES32_TWO);
+      expect(await set.prevMap(BYTES32_FOUR)).to.equal(BYTES32_THREE);
+      expect(await set.nextMap(BYTES32_FOUR)).to.equal(BYTES32_FIVE);
+
+      const first = await set.first();
+      const second = await set.next(first);
+      const third = await set.next(second);
+      const fourth = await set.next(third);
+      const next_of_third = await set.nextMap(fourth);
+
+      expect(first).to.equal(BYTES32_ONE);
+      expect(second).to.equal(BYTES32_THREE);
+      expect(third).to.equal(BYTES32_FOUR);
+      expect(fourth).to.equal(BYTES32_FIVE);
+      expect(next_of_third).to.equal(QUEUE_END);
+    });
   });
 
   it("should recognize empty sets", async () => {
@@ -226,6 +363,9 @@ describe("IterableOrderedOrderSet", function () {
     await set.insert(BYTES32_TWO);
 
     expect(await set.callStatic.remove(BYTES32_THREE)).to.equal(false);
+    expect(await set.callStatic.removeKeepHistory(BYTES32_THREE)).to.equal(
+      false,
+    );
   });
 
   it("can add element BYTES32_ONE => rate of startingElement ==0", async () => {


### PR DESCRIPTION
This PR changes how nodes are removed from the linked list. It introduces a new function `removeKeepHistory` that removes the node from the list while still keeping information on its predecessor onchain. This information can be used in (a modified) `insert` to allow user to refer to deleted nodes as a reference point for inserting. The purpose of this change is to not have any risk of failure condition when a user removes and inserts correctly an order.

### Test plan
New unit tests.