### PR TITLE
Add test function to create auctions with defaults

### DIFF
--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -1,0 +1,14 @@
+import { BigNumberish, BytesLike, Contract } from "ethers";
+
+export interface InitiateAuctionInput {
+  auctioningToken: Contract;
+  biddingToken: Contract;
+  orderCancelationPeriodDuration: BigNumberish;
+  duration: BigNumberish;
+  auctionedSellAmount: BigNumberish;
+  minBuyAmount: BigNumberish;
+  minimumBiddingAmountPerOrder: BigNumberish;
+  minFundingThreshold: BigNumberish;
+  isAtomicClosureAllowed: boolean;
+  allowListManager: BytesLike;
+}

--- a/test/contract/AllowListManager.spec.ts
+++ b/test/contract/AllowListManager.spec.ts
@@ -10,7 +10,7 @@ import {
 } from "../../src/priceCalculation";
 import { TypedDataDomain } from "../../src/ts/ethers";
 
-import { sendTxAndGetReturnValue } from "./utilities";
+import { createAuctionWithDefaults } from "./defaultContractInteractions";
 
 export function domain(
   chainId: number,
@@ -57,19 +57,13 @@ describe("AccessManager", async () => {
         [user_1, user_2],
         hre,
       );
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        ethers.utils.parseEther("1"),
-        ethers.utils.parseEther("1"),
-        1,
-        0,
-        false,
-        allowListManager.address,
+        {
+          auctioningToken,
+          biddingToken,
+          allowListManager: allowListManager.address,
+        },
       );
 
       const auctioneerMessage = ethers.utils.keccak256(
@@ -131,19 +125,13 @@ describe("AccessManager", async () => {
         [user_1, user_2],
         hre,
       );
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        ethers.utils.parseEther("1"),
-        ethers.utils.parseEther("1"),
-        1,
-        0,
-        false,
-        allowListManager.address,
+        {
+          auctioningToken,
+          biddingToken,
+          allowListManager: allowListManager.address,
+        },
       );
 
       const { chainId } = await ethers.provider.getNetwork();

--- a/test/contract/EasyAuction.spec.ts
+++ b/test/contract/EasyAuction.spec.ts
@@ -15,6 +15,7 @@ import {
   getClearingPriceFromInitialOrder,
 } from "../../src/priceCalculation";
 
+import { createAuctionWithDefaults } from "./defaultContractInteractions";
 import {
   sendTxAndGetReturnValue,
   closeAuction,
@@ -151,19 +152,12 @@ describe("EasyAuction", async () => {
 
       const timestampForMining = 2000000000;
       ethers.provider.send("evm_setNextBlockTimestamp", [timestampForMining]);
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        ethers.utils.parseEther("1"),
-        ethers.utils.parseEther("1"),
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+        },
       );
       const auctionData = await easyAuction.auctionData(auctionId);
       expect(auctionData.auctioningToken).to.equal(auctioningToken.address);
@@ -237,19 +231,12 @@ describe("EasyAuction", async () => {
         [user_1, user_2],
         hre,
       );
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        ethers.utils.parseEther("1"),
-        ethers.utils.parseEther("1"),
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+        },
       );
       await closeAuction(easyAuction, auctionId);
       await expect(
@@ -271,19 +258,12 @@ describe("EasyAuction", async () => {
         [user_1, user_2],
         hre,
       );
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        ethers.utils.parseEther("1"),
-        ethers.utils.parseEther("1"),
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+        },
       );
       await expect(
         easyAuction.placeSellOrders(
@@ -313,19 +293,12 @@ describe("EasyAuction", async () => {
         [user_1, user_2],
         hre,
       );
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        ethers.utils.parseEther("1"),
-        ethers.utils.parseEther("1"),
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+        },
       );
       await expect(() =>
         easyAuction.placeSellOrders(
@@ -359,19 +332,12 @@ describe("EasyAuction", async () => {
         [user_1, user_2],
         hre,
       );
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        ethers.utils.parseEther("1"),
-        ethers.utils.parseEther("1"),
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+        },
       );
 
       const balanceBeforeOrderPlacement = await biddingToken.balanceOf(
@@ -409,19 +375,13 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        ethers.utils.parseEther("1"),
-        ethers.utils.parseEther("1"),
-        1,
-        0,
-        false,
-        verifierMocked.address,
+        {
+          auctioningToken,
+          biddingToken,
+          allowListManager: verifierMocked.address,
+        },
       );
 
       const sellAmount = ethers.utils.parseEther("1").add(1);
@@ -446,19 +406,13 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        ethers.utils.parseEther("1"),
-        ethers.utils.parseEther("1"),
-        1,
-        0,
-        false,
-        user_3.address,
+        {
+          auctioningToken,
+          biddingToken,
+          allowListManager: user_3.address,
+        },
       );
 
       const sellAmount = ethers.utils.parseEther("1").add(1);
@@ -488,19 +442,13 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        ethers.utils.parseEther("1"),
-        ethers.utils.parseEther("1"),
-        1,
-        0,
-        false,
-        stateChangingAllowListManager.address,
+        {
+          auctioningToken,
+          biddingToken,
+          allowListManager: stateChangingAllowListManager.address,
+        },
       );
 
       const sellAmount = ethers.utils.parseEther("1").add(1);
@@ -540,19 +488,13 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        ethers.utils.parseEther("1"),
-        ethers.utils.parseEther("1"),
-        1,
-        0,
-        false,
-        verifierMocked.address,
+        {
+          auctioningToken,
+          biddingToken,
+          allowListManager: verifierMocked.address,
+        },
       );
 
       const sellAmount = ethers.utils.parseEther("1").add(1);
@@ -576,19 +518,12 @@ describe("EasyAuction", async () => {
         [user_1, user_2],
         hre,
       );
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        ethers.utils.parseEther("1"),
-        ethers.utils.parseEther("1"),
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+        },
       );
 
       const sellAmount = ethers.utils.parseEther("1").add(1);
@@ -627,19 +562,15 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        ethers.utils.parseEther("1").div(100),
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+          minimumBiddingAmountPerOrder: ethers.utils.parseEther("1").div(100),
+        },
       );
       await expect(
         easyAuction.placeSellOrders(
@@ -660,19 +591,12 @@ describe("EasyAuction", async () => {
         [user_1, user_2],
         hre,
       );
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        ethers.utils.parseEther("1"),
-        ethers.utils.parseEther("1"),
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+        },
       );
       const sellAmount = ethers.utils.parseEther("1").add(1);
       const buyAmount = ethers.utils.parseEther("1");
@@ -726,19 +650,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -769,19 +688,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -823,19 +737,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -887,19 +796,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -1320,19 +1224,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -1371,19 +1270,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -1427,19 +1321,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -1501,19 +1390,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -1584,19 +1468,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -1670,19 +1549,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -1726,19 +1600,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -1789,19 +1658,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -1855,19 +1719,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -1917,19 +1776,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -1973,19 +1827,15 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        ethers.utils.parseEther("5"),
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+          minFundingThreshold: ethers.utils.parseEther("5"),
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -2035,19 +1885,15 @@ describe("EasyAuction", async () => {
       await easyAuction
         .connect(user_1)
         .setFeeParameters(feeNumerator, feeReceiver.address);
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        ethers.utils.parseEther("5"),
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+          minFundingThreshold: ethers.utils.parseEther("5"),
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
       await closeAuction(easyAuction, auctionId);
@@ -2080,19 +1926,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -2131,19 +1972,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -2194,19 +2030,15 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        ethers.utils.parseEther("5"),
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+          minFundingThreshold: ethers.utils.parseEther("5"),
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -2245,19 +2077,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -2302,19 +2129,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -2377,19 +2199,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
       await closeAuction(easyAuction, auctionId);
@@ -2431,19 +2248,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -2488,19 +2300,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -2539,20 +2346,12 @@ describe("EasyAuction", async () => {
       biddingToken,
     } = await createTokensAndMintAndApprove(easyAuction, [user_1, user_2], hre);
 
-    const auctionId: BigNumber = await sendTxAndGetReturnValue(
-      easyAuction,
-      "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-      auctioningToken.address,
-      biddingToken.address,
-      60 * 60,
-      60 * 60,
-      initialAuctionOrder.sellAmount,
-      initialAuctionOrder.buyAmount,
-      1,
-      0,
-      false,
-      "0x0000000000000000000000000000000000000000",
-    );
+    const auctionId: BigNumber = await createAuctionWithDefaults(easyAuction, {
+      auctioningToken,
+      biddingToken,
+      auctionedSellAmount: initialAuctionOrder.sellAmount,
+      minBuyAmount: initialAuctionOrder.buyAmount,
+    });
     await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
     await closeAuction(easyAuction, auctionId);
@@ -2587,20 +2386,12 @@ describe("EasyAuction", async () => {
       biddingToken,
     } = await createTokensAndMintAndApprove(easyAuction, [user_1, user_2], hre);
 
-    const auctionId: BigNumber = await sendTxAndGetReturnValue(
-      easyAuction,
-      "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-      auctioningToken.address,
-      biddingToken.address,
-      60 * 60,
-      60 * 60,
-      initialAuctionOrder.sellAmount,
-      initialAuctionOrder.buyAmount,
-      1,
-      0,
-      false,
-      "0x0000000000000000000000000000000000000000",
-    );
+    const auctionId: BigNumber = await createAuctionWithDefaults(easyAuction, {
+      auctioningToken,
+      biddingToken,
+      auctionedSellAmount: initialAuctionOrder.sellAmount,
+      minBuyAmount: initialAuctionOrder.buyAmount,
+    });
     await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
     await closeAuction(easyAuction, auctionId);
@@ -2656,19 +2447,15 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+          isAtomicClosureAllowed: false,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -2717,19 +2504,15 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        true,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+          isAtomicClosureAllowed: true,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -2773,19 +2556,15 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        true,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+          isAtomicClosureAllowed: true,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -2802,7 +2581,7 @@ describe("EasyAuction", async () => {
         ),
       ).to.be.revertedWith("precalculateSellAmountSum is already too advanced");
     });
-    it(" allows an atomic settlement, if the precalculation are not yet beyond the price of the inserted order", async () => {
+    it("allows an atomic settlement, if the precalculation are not yet beyond the price of the inserted order", async () => {
       const initialAuctionOrder = {
         sellAmount: ethers.utils.parseEther("1"),
         buyAmount: ethers.utils.parseEther("0.5"),
@@ -2831,19 +2610,15 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        true,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+          isAtomicClosureAllowed: true,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -2889,19 +2664,15 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        true,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+          isAtomicClosureAllowed: true,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -2955,19 +2726,15 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        true,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+          isAtomicClosureAllowed: true,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -3015,19 +2782,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -3063,19 +2825,15 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+          duration: 60 * 60 * 60,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -3114,19 +2872,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -3161,19 +2914,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -3206,19 +2954,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
 
@@ -3247,19 +2990,14 @@ describe("EasyAuction", async () => {
         hre,
       );
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await closeAuction(easyAuction, auctionId);
       expect(
@@ -3301,19 +3039,14 @@ describe("EasyAuction", async () => {
         .connect(user_1)
         .setFeeParameters(feeNumerator, feeReceiver.address);
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
       // resets the userId, as they are only given during function call.
@@ -3367,19 +3100,14 @@ describe("EasyAuction", async () => {
         .connect(user_1)
         .setFeeParameters(feeNumerator, feeReceiver.address);
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
       // resets the userId, as they are only given during function call.
@@ -3431,19 +3159,14 @@ describe("EasyAuction", async () => {
         .connect(user_1)
         .setFeeParameters(feeNumerator, feeReceiver.address);
 
-      const auctionId: BigNumber = await sendTxAndGetReturnValue(
+      const auctionId: BigNumber = await createAuctionWithDefaults(
         easyAuction,
-        "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-        auctioningToken.address,
-        biddingToken.address,
-        60 * 60,
-        60 * 60,
-        initialAuctionOrder.sellAmount,
-        initialAuctionOrder.buyAmount,
-        1,
-        0,
-        false,
-        "0x0000000000000000000000000000000000000000",
+        {
+          auctioningToken,
+          biddingToken,
+          auctionedSellAmount: initialAuctionOrder.sellAmount,
+          minBuyAmount: initialAuctionOrder.buyAmount,
+        },
       );
       await placeOrders(easyAuction, sellOrders, auctionId, hre);
       // resets the userId, as they are only given during function call.

--- a/test/contract/EasyAuctionE2E.spec.ts
+++ b/test/contract/EasyAuctionE2E.spec.ts
@@ -6,7 +6,8 @@ import {
   placeOrders,
 } from "../../src/priceCalculation";
 
-import { sendTxAndGetReturnValue, closeAuction } from "./utilities";
+import { createAuctionWithDefaults } from "./defaultContractInteractions";
+import { closeAuction } from "./utilities";
 
 describe("EasyAuction", async () => {
   const [user_1, user_2] = waffle.provider.getWallets();
@@ -23,20 +24,12 @@ describe("EasyAuction", async () => {
       biddingToken,
     } = await createTokensAndMintAndApprove(easyAuction, [user_1, user_2], hre);
     const nrTests = 12; // increase here for better gas estimations, nrTests-2 must be a divisor of 10**18
-    const auctionId: BigNumber = await sendTxAndGetReturnValue(
-      easyAuction,
-      "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
-      auctioningToken.address,
-      biddingToken.address,
-      60 * 60,
-      60 * 60,
-      ethers.utils.parseEther("1000"),
-      ethers.utils.parseEther("1000"),
-      1,
-      0,
-      false,
-      "0x0000000000000000000000000000000000000000",
-    );
+    const auctionId: BigNumber = await createAuctionWithDefaults(easyAuction, {
+      auctioningToken,
+      biddingToken,
+      auctionedSellAmount: ethers.utils.parseEther("1000"),
+      minBuyAmount: ethers.utils.parseEther("1000"),
+    });
 
     for (let i = 2; i < nrTests; i++) {
       const sellOrder = [

--- a/test/contract/defaultContractInteractions.ts
+++ b/test/contract/defaultContractInteractions.ts
@@ -1,0 +1,27 @@
+import { Contract, BigNumber } from "ethers";
+import { ethers } from "hardhat";
+
+import { InitiateAuctionInput } from "../../src/ts/types";
+
+import { sendTxAndGetReturnValue } from "./utilities";
+
+export async function createAuctionWithDefaults(
+  easyAuction: Contract,
+  parameters: Partial<InitiateAuctionInput> &
+    Pick<InitiateAuctionInput, "auctioningToken" | "biddingToken">,
+): Promise<BigNumber> {
+  return sendTxAndGetReturnValue(
+    easyAuction,
+    "initiateAuction(address,address,uint256,uint256,uint96,uint96,uint256,uint256,bool,address)",
+    parameters.auctioningToken.address,
+    parameters.biddingToken.address,
+    parameters.orderCancelationPeriodDuration ?? 60 * 60,
+    parameters.duration ?? 60 * 60,
+    parameters.auctionedSellAmount ?? ethers.utils.parseEther("1"),
+    parameters.minBuyAmount ?? ethers.utils.parseEther("1"),
+    parameters.minimumBiddingAmountPerOrder ?? 1,
+    parameters.minFundingThreshold ?? 0,
+    parameters.isAtomicClosureAllowed ?? false,
+    parameters.allowListManager ?? "0x0000000000000000000000000000000000000000",
+  );
+}


### PR DESCRIPTION
I've noticed that changing the input values of `initiateAuction` always requires many changes to the tests. This takes up developing time and risks introducing issues when manually changing each test.
This PR creates a function `createAuctionWithDefaults`: it allows to create a new auction with a set of default values, each of which can be overridden if needed.

### Test plan
Tests still work.