### PR TITLE
Adding simple signature script

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,21 @@ export PK=PRIVATE_KEY_HERE
 yarn hardhat initiateAuction --auctioning-token "0xc778417e063141139fce010982780140aa0cd5ab" --bidding-token "0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa" --sell-amount 0.1 --min-buy-amount 50 --network $NETWORK
 ```
 
+### Generating signatures
+
+Signatures for an auction with participation restriction can be created like that:
+
+1. Create a file: `your_address_inputs.txt` with comma separated addresses that should be allow-listed for the auction
+2. Initiate the auction and remember your auctionId
+3. Run the following script:
+
+```
+export NETWORK='your network'
+export INFURA_KEY=INFURA_KEY_HERE
+export PK=PRIVATE_KEY_FOR_SIGNING
+yarn hardhat generateSignatures --auction-id "Your auctionId" --file-with-address "./your_address_inputs.txt" --network $NETWORK
+```
+
 ## Audit
 
 The solidity code was audited by Adam Kolar, from the G0 Group. The report can be found [here](https://github.com/g0-group/Audits/blob/master/GnosisAuctionFeb2021.pdf).

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -7,6 +7,7 @@ import type { HttpNetworkUserConfig } from "hardhat/types";
 import yargs from "yargs";
 
 import { clearAuction } from "./src/tasks/clear_auction";
+import { generateSignatures } from "./src/tasks/generateSignatures";
 import { initiateAuction } from "./src/tasks/initiate_new_auction";
 
 const argv = yargs
@@ -41,6 +42,7 @@ if (["rinkeby", "mainnet"].includes(argv.network) && INFURA_KEY === undefined) {
 
 initiateAuction();
 clearAuction();
+generateSignatures();
 
 export default {
   paths: {

--- a/src/tasks/generateSignatures.ts
+++ b/src/tasks/generateSignatures.ts
@@ -4,20 +4,7 @@ import "hardhat-deploy";
 import "@nomiclabs/hardhat-ethers";
 import { task } from "hardhat/config";
 
-import { TypedDataDomain } from "../../src/ts/ethers";
-
-export function domain(
-  chainId: number,
-  verifyingContract: string,
-): TypedDataDomain {
-  return {
-    name: "AccessManager",
-    version: "v1",
-    chainId,
-    verifyingContract,
-  };
-}
-import { getAllowListOffChainManagedContract } from "./utils";
+import { domain, getAllowListOffChainManagedContract } from "./utils";
 
 const generateSignatures: () => void = () => {
   task(
@@ -44,7 +31,7 @@ const generateSignatures: () => void = () => {
       const contractDomain = domain(chainId, allowListContract.address);
 
       const file = fs.readFileSync(taskArgs.fileWithAddress, "utf8");
-      const addresses = file.split(",");
+      const addresses = file.split(",").map((address) => address.trim());
       const signatures = [];
       for (const address of addresses) {
         const auctioneerMessage = hardhatRuntime.ethers.utils.keccak256(

--- a/src/tasks/generateSignatures.ts
+++ b/src/tasks/generateSignatures.ts
@@ -1,0 +1,89 @@
+import fs from "fs";
+
+import "hardhat-deploy";
+import "@nomiclabs/hardhat-ethers";
+import { task } from "hardhat/config";
+
+import { TypedDataDomain } from "../../src/ts/ethers";
+
+export function domain(
+  chainId: number,
+  verifyingContract: string,
+): TypedDataDomain {
+  return {
+    name: "AccessManager",
+    version: "v1",
+    chainId,
+    verifyingContract,
+  };
+}
+import { getAllowListOffChainManagedContract } from "./utils";
+
+const generateSignatures: () => void = () => {
+  task(
+    "generateSignatures",
+    "Generates the signatures for the allowListManager",
+  )
+    .addParam("auctionId", "Id of the auction ")
+    .addParam(
+      "fileWithAddress",
+      "File with comma separated addresses that should be allow-listed",
+    )
+    .setAction(async (taskArgs, hardhatRuntime) => {
+      const [caller] = await hardhatRuntime.ethers.getSigners();
+      console.log(
+        "Using the account: ",
+        caller.address,
+        " to generate signatures",
+      );
+      const allowListContract = await getAllowListOffChainManagedContract(
+        hardhatRuntime,
+      );
+      const { chainId } = await hardhatRuntime.ethers.provider.getNetwork();
+
+      const contractDomain = domain(chainId, allowListContract.address);
+
+      const file = fs.readFileSync(taskArgs.fileWithAddress, "utf8");
+      const addresses = file.split(",");
+      const signatures = [];
+      for (const address of addresses) {
+        const auctioneerMessage = hardhatRuntime.ethers.utils.keccak256(
+          hardhatRuntime.ethers.utils.defaultAbiCoder.encode(
+            ["bytes32", "address", "uint256"],
+            [
+              hardhatRuntime.ethers.utils._TypedDataEncoder.hashDomain(
+                contractDomain,
+              ),
+              address,
+              taskArgs.auctionId,
+            ],
+          ),
+        );
+        const auctioneerSignature = await caller.signMessage(
+          hardhatRuntime.ethers.utils.arrayify(auctioneerMessage),
+        );
+        const sig = hardhatRuntime.ethers.utils.splitSignature(
+          auctioneerSignature,
+        );
+        const auctioneerSignatureEncoded = hardhatRuntime.ethers.utils.defaultAbiCoder.encode(
+          ["uint8", "bytes32", "bytes32"],
+          [sig.v, sig.r, sig.s],
+        );
+        signatures.push(
+          JSON.stringify({
+            address: address,
+            signature: auctioneerSignatureEncoded,
+          }),
+        );
+      }
+      console.log(
+        JSON.stringify({
+          auctionId: taskArgs.auctionId,
+          chainId: chainId,
+          allowListContract: allowListContract.address,
+          signatures: signatures,
+        }),
+      );
+    });
+};
+export { generateSignatures };

--- a/src/tasks/utils.ts
+++ b/src/tasks/utils.ts
@@ -13,3 +13,18 @@ export async function getEasyAuctionContract({
 
   return authenticator;
 }
+export async function getAllowListOffChainManagedContract({
+  ethers,
+  deployments,
+}: HardhatRuntimeEnvironment): Promise<Contract> {
+  const authenticatorDeployment = await deployments.get(
+    "AllowListOffChainManaged",
+  );
+
+  const authenticator = new Contract(
+    authenticatorDeployment.address,
+    authenticatorDeployment.abi,
+  ).connect(ethers.provider);
+
+  return authenticator;
+}

--- a/src/tasks/utils.ts
+++ b/src/tasks/utils.ts
@@ -1,5 +1,20 @@
 import { Contract } from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+import { TypedDataDomain } from "../ts/ethers";
+
+export function domain(
+  chainId: number,
+  verifyingContract: string,
+): TypedDataDomain {
+  return {
+    name: "AccessManager",
+    version: "v1",
+    chainId,
+    verifyingContract,
+  };
+}
+
 export async function getEasyAuctionContract({
   ethers,
   deployments,

--- a/test/contract/AllowListManager.spec.ts
+++ b/test/contract/AllowListManager.spec.ts
@@ -8,9 +8,9 @@ import {
   queueStartElement,
   createTokensAndMintAndApprove,
 } from "../../src/priceCalculation";
+import { domain } from "../../src/tasks/utils";
 
 import { createAuctionWithDefaults } from "./defaultContractInteractions";
-import { domain } from "./utilities";
 
 describe("AccessManager - integration tests", async () => {
   const [user_1, user_2] = waffle.provider.getWallets();

--- a/test/contract/AllowListManager.spec.ts
+++ b/test/contract/AllowListManager.spec.ts
@@ -8,23 +8,11 @@ import {
   queueStartElement,
   createTokensAndMintAndApprove,
 } from "../../src/priceCalculation";
-import { TypedDataDomain } from "../../src/ts/ethers";
 
 import { createAuctionWithDefaults } from "./defaultContractInteractions";
+import { domain } from "./utilities";
 
-export function domain(
-  chainId: number,
-  verifyingContract: string,
-): TypedDataDomain {
-  return {
-    name: "AccessManager",
-    version: "v1",
-    chainId,
-    verifyingContract,
-  };
-}
-
-describe("AccessManager", async () => {
+describe("AccessManager - integration tests", async () => {
   const [user_1, user_2] = waffle.provider.getWallets();
   let easyAuction: Contract;
   let allowListManager: Contract;

--- a/test/contract/EasyAuction.spec.ts
+++ b/test/contract/EasyAuction.spec.ts
@@ -21,6 +21,7 @@ import {
   closeAuction,
   increaseTime,
   claimFromAllOrders,
+  MAGIC_VALUE_FROM_ALLOW_LIST_VERIFIER_INTERFACE,
 } from "./utilities";
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -31,7 +32,6 @@ import {
 describe("EasyAuction", async () => {
   const [user_1, user_2, user_3] = waffle.provider.getWallets();
   let easyAuction: Contract;
-  const MAGIC_VALUE_FROM_ALLOW_LIST_VERIFIER_INTERFACE = "0x19a05a7e";
   beforeEach(async () => {
     const EasyAuction = await ethers.getContractFactory("EasyAuction");
 

--- a/test/contract/utilities.ts
+++ b/test/contract/utilities.ts
@@ -2,21 +2,8 @@ import { BigNumber, Contract } from "ethers";
 import { ethers } from "hardhat";
 
 import { encodeOrder, Order } from "../../src/priceCalculation";
-import { TypedDataDomain } from "../../src/ts/ethers";
 
 export const MAGIC_VALUE_FROM_ALLOW_LIST_VERIFIER_INTERFACE = "0x19a05a7e";
-
-export function domain(
-  chainId: number,
-  verifyingContract: string,
-): TypedDataDomain {
-  return {
-    name: "AccessManager",
-    version: "v1",
-    chainId,
-    verifyingContract,
-  };
-}
 
 export async function closeAuction(
   instance: Contract,

--- a/test/contract/utilities.ts
+++ b/test/contract/utilities.ts
@@ -2,6 +2,21 @@ import { BigNumber, Contract } from "ethers";
 import { ethers } from "hardhat";
 
 import { encodeOrder, Order } from "../../src/priceCalculation";
+import { TypedDataDomain } from "../../src/ts/ethers";
+
+export const MAGIC_VALUE_FROM_ALLOW_LIST_VERIFIER_INTERFACE = "0x19a05a7e";
+
+export function domain(
+  chainId: number,
+  verifyingContract: string,
+): TypedDataDomain {
+  return {
+    name: "AccessManager",
+    version: "v1",
+    chainId,
+    verifyingContract,
+  };
+}
 
 export async function closeAuction(
   instance: Contract,


### PR DESCRIPTION
This PR replaces #71 for easier mergeability.

todo in next PR: 
[] Check for signature verification for this auction ID by reading the actual verified from the settlement contract and comparing.
[] implement optional sending of signatures to API-endpoint.
[] option to safe the result in output.json file

