### PR TITLE
Adjust command line arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build
 env/*
 coverage/*
 coverage.json
+your_address_inputs.txt
+signatures.json

--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ Signatures for an auction with participation restriction can be created like tha
 3. Run the following script:
 
 ```
-export NETWORK='your network'
-export INFURA_KEY=INFURA_KEY_HERE
-export PK=PRIVATE_KEY_FOR_SIGNING
+export NETWORK=<Your Network>
+export INFURA_KEY=<Your infura key>
+export PK=<Your private key _for the signing address_. The address for this key should not hold any ETH>
 yarn hardhat generateSignatures --auction-id "Your auctionId" --file-with-address "./your_address_inputs.txt" --network $NETWORK
 ```
 

--- a/src/tasks/generateSignatures.ts
+++ b/src/tasks/generateSignatures.ts
@@ -17,7 +17,7 @@ const generateSignatures: () => void = () => {
       "fileWithAddress",
       "File with comma separated addresses that should be allow-listed",
     )
-    .addOptionalParam(
+    .addFlag(
       "postToApi",
       "Flag that indicates whether the signatures should be sent directly to the api",
     )


### PR DESCRIPTION
A small PR that fixes some very minor issues that I noticed while doing a test run.

Using `addFlag` instead of `addOptionalParam` makes the command consistent with the readme: `postToApi` is true if the string `--post-to-api` appears as an argument to the executed command. Without this PR, the user still needs to use `--post-to-api true`.