### PR TITLE
Small optimisation mentioned in second audit

### DIFF
--- a/contracts/libraries/IterableOrderedOrderSet.sol
+++ b/contracts/libraries/IterableOrderedOrderSet.sol
@@ -143,8 +143,9 @@ library IterableOrderedOrderSet {
     }
 
     // @dev orders are ordered by
-    // 1. their price - buyAmount/sellAmount and
-    // 2. their userId,
+    // 1. their price - buyAmount/sellAmount
+    // 2. by the sellAmount
+    // 3. their userId,
     function smallerThan(bytes32 orderLeft, bytes32 orderRight)
         internal
         pure
@@ -170,6 +171,8 @@ library IterableOrderedOrderSet {
             priceNumeratorRight.mul(priceDenominatorLeft)
         ) return false;
 
+        if (priceNumeratorLeft < priceNumeratorRight) return true;
+        if (priceNumeratorLeft > priceNumeratorRight) return false;
         require(
             userIdLeft != userIdRight,
             "user is not allowed to place same order twice"

--- a/test/contract/IteratableOrderSet.spec.ts
+++ b/test/contract/IteratableOrderSet.spec.ts
@@ -21,9 +21,9 @@ const BYTES32_ONE = encodeOrder({
   buyAmount: BigNumber.from(2),
 });
 const BYTES32_ONE_DIFFERENT = encodeOrder({
-  userId: BigNumber.from(3),
-  sellAmount: BigNumber.from(2),
-  buyAmount: BigNumber.from(2),
+  userId: BigNumber.from(2),
+  sellAmount: BigNumber.from(3),
+  buyAmount: BigNumber.from(3),
 });
 const BYTES32_ONE_BEST_USER = encodeOrder({
   userId: BigNumber.from(1),
@@ -31,7 +31,7 @@ const BYTES32_ONE_BEST_USER = encodeOrder({
   buyAmount: BigNumber.from(2),
 });
 const BYTES32_ONE_BEST_AMOUNT = encodeOrder({
-  userId: BigNumber.from(3),
+  userId: BigNumber.from(2),
   sellAmount: BigNumber.from(1),
   buyAmount: BigNumber.from(1),
 });
@@ -150,9 +150,9 @@ describe("IterableOrderedOrderSet", function () {
     expect(await set.callStatic.insert(BYTES32_ONE_DIFFERENT)).to.equal(false);
   });
   it("should throw if the same orders are compared with smallerThan", async () => {
-    await expect(
-      set.smallerThan(BYTES32_ONE_DIFFERENT, BYTES32_ONE_DIFFERENT),
-    ).to.be.revertedWith("user is not allowed to place same order twice");
+    await expect(set.smallerThan(BYTES32_ONE, BYTES32_ONE)).to.be.revertedWith(
+      "user is not allowed to place same order twice",
+    );
   });
 
   it("should allow to insert element at certain element", async () => {

--- a/test/contract/IteratableOrderSet.spec.ts
+++ b/test/contract/IteratableOrderSet.spec.ts
@@ -124,7 +124,7 @@ describe("IterableOrderedOrderSet", function () {
     expect(fourth).to.equal(BYTES32_TWO);
     expect(fifth).to.equal(BYTES32_THREE);
   });
-  it("should allow to iterate over content and check order - part 1", async () => {
+  it("should allow to iterate over content and check order - part 2", async () => {
     await set.insert(BYTES32_ONE);
     await set.insert(BYTES32_ONE_BEST_AMOUNT);
     await set.insert(BYTES32_ONE_BEST_USER);

--- a/test/contract/IteratableOrderSet.spec.ts
+++ b/test/contract/IteratableOrderSet.spec.ts
@@ -17,11 +17,11 @@ const BYTES32_ZERO = encodeOrder({
 });
 const BYTES32_ONE = encodeOrder({
   userId: BigNumber.from(2),
-  sellAmount: BigNumber.from(1),
-  buyAmount: BigNumber.from(1),
+  sellAmount: BigNumber.from(2),
+  buyAmount: BigNumber.from(2),
 });
 const BYTES32_ONE_DIFFERENT = encodeOrder({
-  userId: BigNumber.from(2),
+  userId: BigNumber.from(3),
   sellAmount: BigNumber.from(2),
   buyAmount: BigNumber.from(2),
 });
@@ -29,6 +29,11 @@ const BYTES32_ONE_BEST_USER = encodeOrder({
   userId: BigNumber.from(1),
   sellAmount: BigNumber.from(2),
   buyAmount: BigNumber.from(2),
+});
+const BYTES32_ONE_BEST_AMOUNT = encodeOrder({
+  userId: BigNumber.from(3),
+  sellAmount: BigNumber.from(1),
+  buyAmount: BigNumber.from(1),
 });
 const BYTES32_TWO = encodeOrder({
   userId: BigNumber.from(2),
@@ -100,27 +105,54 @@ describe("IterableOrderedOrderSet", function () {
     expect(await set.first()).to.equal(BYTES32_ONE);
   });
 
-  it("should allow to iterate over content", async () => {
+  it("should allow to iterate over content and check order - part 1", async () => {
     await set.insert(BYTES32_ONE);
     await set.insert(BYTES32_TWO);
     await set.insert(BYTES32_THREE);
     await set.insert(BYTES32_ONE_BEST_USER);
+    await set.insert(BYTES32_ONE_BEST_AMOUNT);
 
     const first = await set.first();
     const second = await set.next(first);
     const third = await set.next(second);
     const fourth = await set.next(third);
+    const fifth = await set.next(fourth);
 
-    expect(first).to.equal(BYTES32_ONE_BEST_USER);
-    expect(second).to.equal(BYTES32_ONE);
-    expect(third).to.equal(BYTES32_TWO);
-    expect(fourth).to.equal(BYTES32_THREE);
+    expect(first).to.equal(BYTES32_ONE_BEST_AMOUNT);
+    expect(second).to.equal(BYTES32_ONE_BEST_USER);
+    expect(third).to.equal(BYTES32_ONE);
+    expect(fourth).to.equal(BYTES32_TWO);
+    expect(fifth).to.equal(BYTES32_THREE);
   });
-  it("should not allow to insert same limit price with same user", async () => {
+  it("should allow to iterate over content and check order - part 1", async () => {
     await set.insert(BYTES32_ONE);
-    await expect(set.insert(BYTES32_ONE_DIFFERENT)).to.be.revertedWith(
-      "user is not allowed to place same order twice",
-    );
+    await set.insert(BYTES32_ONE_BEST_AMOUNT);
+    await set.insert(BYTES32_ONE_BEST_USER);
+    await set.insert(BYTES32_TWO);
+    await set.insert(BYTES32_THREE);
+
+    const first = await set.first();
+    const second = await set.next(first);
+    const third = await set.next(second);
+    const fourth = await set.next(third);
+    const fifth = await set.next(fourth);
+
+    expect(first).to.equal(BYTES32_ONE_BEST_AMOUNT);
+    expect(second).to.equal(BYTES32_ONE_BEST_USER);
+    expect(third).to.equal(BYTES32_ONE);
+    expect(fourth).to.equal(BYTES32_TWO);
+    expect(fifth).to.equal(BYTES32_THREE);
+  });
+  it("should allow to insert same limit price with different amount with same user", async () => {
+    await set.insert(BYTES32_ONE);
+    expect(await set.callStatic.insert(BYTES32_ONE_DIFFERENT)).to.equal(true);
+    await set.insert(BYTES32_ONE_DIFFERENT);
+    expect(await set.callStatic.insert(BYTES32_ONE_DIFFERENT)).to.equal(false);
+  });
+  it("should throw if the same orders are compared with smallerThan", async () => {
+    await expect(
+      set.smallerThan(BYTES32_ONE_DIFFERENT, BYTES32_ONE_DIFFERENT),
+    ).to.be.revertedWith("user is not allowed to place same order twice");
   });
 
   it("should allow to insert element at certain element", async () => {


### PR DESCRIPTION
Fixes the following mentioning, which we could also fix by always requiring high min-sell-amounts-per order.

>Allowing users to submit orders on other people's behalf opens an interesting DoS attack vector. An attacker can frontrun order of a user with placing an order with the same price, but tiny value on their behalf. This will lead to IterableOrderedOrderSet.smallerThan function throwing. Economical viability of such attack depends on the value of minimumBiddingAmountPerOrder. (edited) 

