### PR TITLE
mainnet support for getNetworkName

### DIFF
--- a/src/tasks/generateSignatures.ts
+++ b/src/tasks/generateSignatures.ts
@@ -139,8 +139,11 @@ async function getNetworkName(
 ): Promise<string> {
   const networkInfo = await hardhatRuntime.ethers.provider.getNetwork();
   let networkName = networkInfo.name;
-  if (networkInfo.chainId == 100) {
+  if (networkInfo.chainId === 100) {
     networkName = "xdai";
+  }
+  if (networkInfo.chainId === 1) {
+    networkName = "mainnet";
   }
   return networkName;
 }


### PR DESCRIPTION
Tiny fix. Sometimes HardhatRuntimeEnvironment has different names for mainnet network, like "homestead"...